### PR TITLE
Append query string to coveralls badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Interview Foundation Build
 
 [![Build Status](https://travis-ci.org/krmroland/interview_foundation.svg?branch=master)](https://travis-ci.org/krmroland/interview_foundation)
-<a href='https://coveralls.io/github/krmroland/interview_foundation?branch=master'><img src='https://coveralls.io/repos/github/krmroland/interview_foundation/badge.svg?branch=master' alt='Coverage Status' /></a>
+<a href='https://coveralls.io/github/krmroland/interview_foundation?branch=master'><img src='https://coveralls.io/repos/github/krmroland/interview_foundation/badge.svg?branch=master&github' alt='Coverage Status' /></a>
 
 ## My favorite Github Repositories
 


### PR DESCRIPTION
- For some reason, the coveralls badge is not updating and the general consensus on the internet is to temporarily append a query string to the URL which should help burst the cache.