### PR TITLE
[Fix] don't  share the  same github api instance between users

### DIFF
--- a/app/Providers/GithubServiceProvider.php
+++ b/app/Providers/GithubServiceProvider.php
@@ -16,7 +16,7 @@ class GithubServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app->singleton(GithubApi::class, function ($app) {
+        $this->app->bind(GithubApi::class, function ($app) {
             return new PhpGithubApi($app->make(Client::class));
         });
     }

--- a/app/User.php
+++ b/app/User.php
@@ -3,6 +3,7 @@
 namespace App;
 
 use App\Casts\Encrypted;
+use Illuminate\Support\Facades\Hash;
 use Illuminate\Notifications\Notifiable;
 use App\Services\GitHub\Contracts\GithubApi;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
@@ -42,7 +43,7 @@ class User extends Authenticatable
      */
     public function setPasswordAttribute($password)
     {
-        $this->attributes['password'] = bcrypt($password);
+        $this->attributes['password'] = Hash::make($password);
     }
     /**
      * The users github client

--- a/tests/Feature/Auth/UserGithubPhpApiTest.php
+++ b/tests/Feature/Auth/UserGithubPhpApiTest.php
@@ -33,4 +33,12 @@ class UserGithubTest extends TestCase
 
         $this->assertSame($user->github()->getUserStarredRepositories(), $response);
     }
+
+    public function testUsersShouldNotShareTheSameGithubInstance()
+    {
+        $first = factory(User::class)->create(['github_token' => 'first-user-token']);
+        $second = factory(User::class)->create(['github_token' => 'second-user-token']);
+
+        $this->assertNotSame($first->github(), $second->github());
+    }
 }


### PR DESCRIPTION
### What does this PR do?
Currently, the GithubApi is registered as a singleton in the laravel's container which would be okay if we were using a single GitHub token for all the users. 

The expected behavior is to create a fresh instance for every user since they all have different tokens. 